### PR TITLE
Updates deprecated options

### DIFF
--- a/.config/isync/mbsyncrc
+++ b/.config/isync/mbsyncrc
@@ -25,8 +25,8 @@ Flatten .
 
 Channel ACCOUNT_ALIAS
 Expunge Both
-Master :ACCOUNT_ALIAS-remote:
-Slave :ACCOUNT_ALIAS-local:
+Far :ACCOUNT_ALIAS-remote:
+Near :ACCOUNT_ALIAS-local:
 Patterns *
 Create Both
 SyncState *
@@ -57,8 +57,8 @@ Flatten .
 
 Channel ACCOUNT_ALIAS
 Expunge Both
-Master :ACCOUNT_ALIAS-remote:
-Slave :ACCOUNT_ALIAS-local:
+Far :ACCOUNT_ALIAS-remote:
+Near :ACCOUNT_ALIAS-local:
 Patterns * ![Gmail]* "[Gmail]/Sent Mail" "[Gmail]/Starred" "[Gmail]/All Mail"
 Create Both
 SyncState *
@@ -92,8 +92,8 @@ Flatten .
 
 Channel ACCOUNT_ALIAS
 Expunge Both
-Master :ACCOUNT_ALIAS-remote:
-Slave :ACCOUNT_ALIAS-local:
+Far :ACCOUNT_ALIAS-remote:
+Near :ACCOUNT_ALIAS-local:
 Create Both
 SyncState *
 MaxMessages 1000
@@ -125,8 +125,8 @@ Flatten .
 
 Channel ACCOUNT_ALIAS
 Expunge Both
-Master :ACCOUNT_ALIAS-remote:
-Slave :ACCOUNT_ALIAS-local:
+Far :ACCOUNT_ALIAS-remote:
+Near :ACCOUNT_ALIAS-local:
 Patterns *
 Create Both
 SyncState *

--- a/bin/mailsync
+++ b/bin/mailsync
@@ -37,7 +37,7 @@ syncandnotify() {
     new=$(find "$HOME/.local/share/mail/$acc/INBOX/new/" "$HOME/.local/share/mail/$acc/Inbox/new/" "$HOME/.local/share/mail/$acc/inbox/new/" -type f -newer "$HOME/.config/mutt/.mailsynclastrun" 2> /dev/null)
     newcount=$(echo "$new" | sed '/^\s*$/d' | wc -l)
     if [ "$newcount" -gt "0" ]; then
-        notify "$acc" "$newcount" &
+        notify-send "$acc" "$newcount" &
         for file in $new; do
             # Extract subject and sender from mail.
             from=$(awk '/^From: / && ++n ==1,/^\<.*\>:/' "$file" | perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' | awk '{ $1=""; if (NF>=3)$NF=""; print $0 }' | sed 's/^[[:blank:]]*[\"'\''\<]*//;s/[\"'\''\>]*[[:blank:]]*$//')


### PR DESCRIPTION
- `isync` deprecated `Master` and `Slave` channels from `mbsyncrc` in favour of `Far` and `Near`. 

- Corrects typo in the `mailsync` script.