### PR TITLE
Adding GPG examples for PassCmd and Passwordeval

### DIFF
--- a/.config/isync/mbsyncrc
+++ b/.config/isync/mbsyncrc
@@ -9,10 +9,16 @@
 # Change ACCOUNT_ALIAS to something meaningful (e.g. personal, work) - this should
 # match the account alias used in .config/mutt/accounts/*
 IMAPStore ACCOUNT_ALIAS-remote
-Host my.imap.host # (check your email providers imap documentation)
-Port 993 # (check your email providers imap documentation)
+# (check your email providers imap documentation)
+Host my.imap.host
+# (check your email providers imap documentation)
+Port 993
 User myemail@domain.com
-PassCmd "pass my-email-password" # how to get your password ('pass' is great for storing these)
+# how to get your password ('pass' and 'gpg' are good for these)
+# using 'pass')
+PassCmd "pass my-email-password"
+# using 'gpg'
+#PassCmd "gpg2 -q --for-your-eyes-only --no-tty -d my-email-password.gpg"
 AuthMechs LOGIN
 SSLType IMAPS
 CertificateFile /etc/ssl/certs/ca-certificates.crt
@@ -44,7 +50,11 @@ Port 993
 User myemail@gmail.com
 # NOTE that if you use 2FA you will have to generate an app password to use
 # here instead: https://support.google.com/accounts/answer/185833?hl=en
-PassCmd "pass my-gmail-password" # how to get your password ('pass' is great for storing these)
+# how to get your password ('pass' and 'gpg' are good for these)
+# using 'pass')
+PassCmd "pass my-gmail-password"
+# using 'gpg'
+#PassCmd "gpg2 -q --for-your-eyes-only --no-tty -d my-gmail-password.gpg"
 AuthMechs LOGIN
 SSLType IMAPS
 CertificateFile /etc/ssl/certs/ca-certificates.crt
@@ -79,7 +89,11 @@ User myemail@corporateoverlords.com
 # https://support.microsoft.com/en-us/account-billing/manage-app-passwords-for-two-step-verification-d6dc8c6d-4bf7-4851-ad95-6d07799387e9
 # If you can't do this you might have to use the DavMail approach instead of
 # direct IMAP - see below
-PassCmd "pass my-owa-password" # how to get your password ('pass' is great for storing these)
+# how to get your password ('pass' and 'gpg' are good for these)
+# using 'pass')
+PassCmd "pass my-owa-password"
+# using 'gpg'
+#PassCmd "gpg2 -q --for-your-eyes-only --no-tty -d my-owa-password.gpg"
 AuthMechs LOGIN
 SSLType IMAPS
 CertificateFile /etc/ssl/certs/ca-certificates.crt
@@ -110,10 +124,15 @@ ExpireUnread no
 # you have it running locally as opposed to on a server somewhere
 IMAPStore ACCOUNT_ALIAS-remote
 Host 127.0.0.1
-Port 1143 # default port used by DavMail - change if needed
+# default port used by DavMail - change if needed
+Port 1143
 User myemail@corporateoverlords.com
 # use your main login password
-PassCmd "pass my-owa-password" # how to get your password ('pass' is great for storing these)
+# how to get your password ('pass' and 'gpg' are good for these)
+# using 'pass')
+PassCmd "pass my-owa-password"
+# using 'gpg'
+#PassCmd "gpg2 -q --for-your-eyes-only --no-tty -d my-owa-password.gpg"
 SSLType none
 AuthMechs LOGIN
 

--- a/.config/msmtp/config
+++ b/.config/msmtp/config
@@ -1,3 +1,4 @@
+# vim:filetype=msmtp
 ## Used to configure your SMTP settings
 # the ACCOUNT_ALIAS used here should match the one you used in your mutt and
 # isync configs
@@ -11,11 +12,15 @@ logfile	~/.config/msmtp/msmtp.log
 
 # Example generic SMTP
 account ACCOUNT_ALIAS
-host my.imap.host # (check your email providers smtp documentation)
+# (check your email providers smtp documentation)
+host my.imap.host
 port 587
 from me@myemail.com
 user me@myemail.com
-passwordeval "pass my-email-password" # how to get your password ('pass' is great for storing these)
+# how to get your password ('pass' example)
+passwordeval "pass my-email-password"
+# how to get your password ('gpg' example)
+# passwordeval "gpg --quiet --for-your-eyes-only --no-tty --decrypt my-email-password"
 
 
 # Example google SMTP
@@ -26,7 +31,10 @@ from myemail@gmail.com
 user myemail@gmail.com
 # NOTE that if you use 2FA you will have to generate an app password to use
 # here instead: https://support.google.com/accounts/answer/185833?hl=en
-passwordeval "pass my-gmail-password" # how to get your password ('pass' is great for storing these)
+# how to get your password ('pass' example)
+passwordeval "pass my-email-password"
+# how to get your password ('gpg' example)
+# passwordeval "gpg --quiet --for-your-eyes-only --no-tty --decrypt my-email-password"
 
 
 # Example outlook/office365 via SMTP
@@ -40,7 +48,10 @@ user myemail@corporateoverlords.com
 # https://support.microsoft.com/en-us/account-billing/manage-app-passwords-for-two-step-verification-d6dc8c6d-4bf7-4851-ad95-6d07799387e9
 # If you can't do this you might have to use the DavMail approach instead of
 # direct IMAP - see below
-passwordeval "pass my-owa-password" # how to get your password ('pass' is great for storing these)
+# how to get your password ('pass' example)
+passwordeval "pass my-owa-password"
+# how to get your password ('gpg' example)
+# passwordeval "gpg --quiet --for-your-eyes-only --no-tty --decrypt my-owa-password"
 
 
 # Example outlook/office365 (DavMail method)
@@ -55,5 +66,7 @@ auth login
 from myemail@corporateoverlords.com
 user myemail@corporateoverlords.com
 # Use your normal login password
-passwordeval "pass my-owa-password" # how to get your password ('pass' is great for storing these)
-
+# how to get your password ('pass' example)
+passwordeval "pass my-owa-password"
+# how to get your password ('gpg' example)
+# passwordeval "gpg --quiet --for-your-eyes-only --no-tty --decrypt my-owa-password"


### PR DESCRIPTION
This adds GPG (2) examples for password retrieval.

Minor fix: Removes inlay comments for `PassCmd` in favour of comments in dedicated lines because `PassCmd` would parse the comments to the command to execute for password retrieval - resulting in an invalid command. I moved them to their own line above the related fields. For consistency's sake, I also moved them in passwordeval (`msmtp/config`), although I had no such issues with this file regarding inlay comments.

Please have a look. 
Cheers